### PR TITLE
Fix CauldronContents potion comparison

### DIFF
--- a/src/main/java/cc/cassian/cauldrons/core/CauldronContents.java
+++ b/src/main/java/cc/cassian/cauldrons/core/CauldronContents.java
@@ -76,7 +76,7 @@ public record CauldronContents(Identifier id, Optional<Holder<Potion>> potion, O
     }
 
     public boolean is(Holder<Potion> potion) {
-        return this.potion.isPresent() && this.potion.get().equals(potion.value()) && this.customEffects.isEmpty();
+        return this.potion.isPresent() && this.potion.get().equals(potion) && this.customEffects.isEmpty();
     }
 
     public boolean is(Identifier potion) {


### PR DESCRIPTION
The current implementation calls `.equals` on a `Holder<Potion>` and a `Potion`, which will never succeed. This meant that no brewing recipes with potion-type `potion` field worked besides the builtin brewing stand fallback.