### PR TITLE
Add milk contents item

### DIFF
--- a/src/main/java/cc/cassian/cauldrons/compat/jei/Constants.java
+++ b/src/main/java/cc/cassian/cauldrons/compat/jei/Constants.java
@@ -16,6 +16,7 @@ public class Constants {
 			Identifier.withDefaultNamespace("powder_snow_cauldron"), new ItemStack(Blocks.POWDER_SNOW),
 			CauldronMod.of("lava"), new ItemStack(Blocks.LAVA),
 			CauldronMod.of("empty"), new ItemStack(Items.AIR),
-			CauldronMod.of("honey"), new ItemStack(CauldronModItems.HONEY_CONTENTS)
+			CauldronMod.of("honey"), new ItemStack(CauldronModItems.HONEY_CONTENTS),
+			CauldronMod.of("milk"), new ItemStack(CauldronModItems.MILK_CONTENTS)
 	);
 }

--- a/src/main/java/cc/cassian/cauldrons/registry/CauldronModItems.java
+++ b/src/main/java/cc/cassian/cauldrons/registry/CauldronModItems.java
@@ -20,6 +20,10 @@ public class CauldronModItems {
             "honey", Item::new, new Item.Properties()
     );
 
+    public static final Item MILK_CONTENTS = register(
+            "milk", Item::new, new Item.Properties()
+    );
+
     private static Item register(ResourceKey<Item> resourceKey, Function<Item.Properties, Item> function, Item.Properties properties) {
         return CommonRegistry.registerItem(resourceKey.identifier().getPath(), function.apply(properties.setId(resourceKey)));
     }

--- a/src/main/resources/assets/toil_and_trouble/items/milk.json
+++ b/src/main/resources/assets/toil_and_trouble/items/milk.json
@@ -1,0 +1,6 @@
+{
+  "model": {
+    "type": "minecraft:model",
+    "model": "toil_and_trouble:item/milk"
+  }
+}

--- a/src/main/resources/assets/toil_and_trouble/lang/en_us.json
+++ b/src/main/resources/assets/toil_and_trouble/lang/en_us.json
@@ -11,6 +11,7 @@
     "cauldron.toil_and_trouble.lava": "Lava",
     "cauldron.toil_and_trouble.water": "Water",
     "item.toil_and_trouble.honey": "Honey",
+    "item.toil_and_trouble.milk": "Milk",
     "config.jade.plugin_toil_and_trouble.cauldron": "Cauldron Brewing",
     "subtitles.toil_and_trouble.block.cauldron.brews": "Cauldron brews",
     "gui.toil_and_trouble.doses": "Contains %s Bottles:",

--- a/src/main/resources/assets/toil_and_trouble/models/item/milk.json
+++ b/src/main/resources/assets/toil_and_trouble/models/item/milk.json
@@ -1,0 +1,6 @@
+{
+    "parent": "item/generated",
+    "textures": {
+        "layer0": "toil_and_trouble:block/milk_still"
+    }
+}


### PR DESCRIPTION
Adds a milk contents item analogous to the honey contents, so that recipes that require milk will show up properly in recipe viewers.
